### PR TITLE
line needed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ local_features:
     - collection_landing_page
     - islandora_collection_landing_pages
     - blocks_lsu
+    - islandora_mods_display_changes
 
 local_mods:
     - islandora_mods_display


### PR DESCRIPTION
in local features list
islandora_mods_display_changes must be enabled to use islandora_mods_display
features list is no longer used to download, only to enable
